### PR TITLE
Add regex to filter out ANSI color codes

### DIFF
--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -127,7 +127,7 @@ export default class SauceService implements Services.ServiceInstance {
         const { error } = results
         if (error && !this._isUP){
             const lines = error.stack.split(/\r?\n/).slice(0, this._maxErrorStackLength)
-            lines.forEach((line:string) => this._browser!.execute('sauce:context=' + line.replaceAll("$'\e'[\[(]*([0-9;])[@-n]/)", "")
+            lines.forEach((line:string) => this._browser!.execute('sauce:context=' + line.replace(/[[]\d\d\w-?\+?/g, "")
         }
 
         /**

--- a/packages/wdio-sauce-service/src/service.ts
+++ b/packages/wdio-sauce-service/src/service.ts
@@ -127,7 +127,7 @@ export default class SauceService implements Services.ServiceInstance {
         const { error } = results
         if (error && !this._isUP){
             const lines = error.stack.split(/\r?\n/).slice(0, this._maxErrorStackLength)
-            lines.forEach((line:string) => this._browser!.execute('sauce:context=' + line))
+            lines.forEach((line:string) => this._browser!.execute('sauce:context=' + line.replaceAll("$'\e'[\[(]*([0-9;])[@-n]/)", "")
         }
 
         /**

--- a/packages/wdio-sauce-service/tests/service.test.ts
+++ b/packages/wdio-sauce-service/tests/service.test.ts
@@ -426,6 +426,20 @@ test('_uploadLogs should not fail in case of a platform error', async () => {
     expect(log.error).toHaveBeenCalledTimes(1)
 })
 
+test('_uploadLogs should strip out any ANSI color codes', async () => {
+  const service = new SauceService(
+      {},
+      {},
+      { outputDir: '/foo/bar' } as any
+  )
+  await service['_uploadLogs']('[32m-ANSItest[39m')
+  expect((got as any as jest.Mock).mock.calls).toHaveLength(1)
+  expect((got as any as jest.Mock)).toHaveBeenCalledWith(
+      'https://api.us-west-1.saucelabs.com/v1/testrunner/jobs/ANSItest/assets',
+      expect.any(Object)
+  )
+})
+
 test('after with bail set', async () => {
     const service = new SauceService({}, {}, { user: 'foobar', key: '123', mochaOpts: { bail: 1 } } as any)
     service['_browser'] = browser


### PR DESCRIPTION
## Proposed changes

Closes #1 6662

[//]: # The sending of ANSI color codes by the expect-webdriverio assertion library results in some of the assertions requiring the ANSI codes, and thus failing inappropriately. We will prevent this by matching on ANSI color codes with regex and filtering them out.


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
